### PR TITLE
feat: improve iOS selector support

### DIFF
--- a/backend/pom_ios.json
+++ b/backend/pom_ios.json
@@ -1,1 +1,10 @@
-{}
+{
+  "au.com.bws.uat": {
+    "initial - button": "~LOG IN",
+    "login - ‘Email’": "~Email",
+    "login - ‘Password’": "~Password",
+    "login - button": "~Log in",
+    "home - page.": "~Delivery",
+    "home - 'search'": "~What can we get you?"
+  }
+}

--- a/backend/src/services/nlp_service.js
+++ b/backend/src/services/nlp_service.js
@@ -34,9 +34,9 @@ async function translateStepsToCommands(rawSteps, pageSource, aiService) {
         The JSON objects must have the following properties:
         - "command": (String) The action to perform. Supported commands are: "click", "setValue", "verifyVisible", "launchApp".
         - "selector": (String) The best selector for the target UI element based on the XML source. Prefer accessibility IDs.
-          * For **Android**, prioritize `resource-id`, then `content-desc`.
-          * For **iOS**, prioritize the element's `name` or `label` attributes.
-          * When using an accessibility identifier, prefix the selector with `~`.
+          * For **Android**, prioritize 'resource-id', then 'content-desc'.
+          * For **iOS**, prioritize the element's 'name' or 'label' attributes.
+          * When using an accessibility identifier, prefix the selector with '~'.
           * Use a precise XPath only if no stable accessibility identifier or resource-id is available.
         - "value": (String) The text to be entered into a field.
         - "original_step": (String) The original, unmodified natural language step.
@@ -78,9 +78,9 @@ async function getPageLoadIndicator(pageName, pageSource, aiService) {
         Analyze the provided XML page source and identify the single, most reliable selector for a stable element that is always present on the "${pageName}" page (e.g., a title, a navigation bar, or a main layout).
 
         Prefer stable accessibility identifiers when choosing a selector.
-        - On **Android**, look for `resource-id` first and then `content-desc`.
-        - On **iOS**, prefer the element's `name` or `label` attributes.
-        Prefix accessibility identifiers with `~`.
+        - On **Android**, look for 'resource-id' first and then 'content-desc'.
+        - On **iOS**, prefer the element's 'name' or 'label' attributes.
+        Prefix accessibility identifiers with '~'.
 
         **XML Page Source:**
         \`\`\`xml
@@ -183,7 +183,7 @@ async function findCorrectSelector(originalStep, pageSource, aiService) {
         2. **content-desc** (Android accessibility ID) or **name/label** (iOS)
         3. **A precise XPath**
 
-        Prefix accessibility identifiers with `~` in the selector string.
+        Prefix accessibility identifiers with '~' in the selector string.
 
         Here is the context:
 

--- a/backend/src/services/nlp_service.js
+++ b/backend/src/services/nlp_service.js
@@ -33,7 +33,11 @@ async function translateStepsToCommands(rawSteps, pageSource, aiService) {
 
         The JSON objects must have the following properties:
         - "command": (String) The action to perform. Supported commands are: "click", "setValue", "verifyVisible", "launchApp".
-        - "selector": (String) The best selector for the target UI element based on the XML source. Prioritize selectors in this order: 1. resource-id, 2. content-desc.
+        - "selector": (String) The best selector for the target UI element based on the XML source. Prefer accessibility IDs.
+          * For **Android**, prioritize `resource-id`, then `content-desc`.
+          * For **iOS**, prioritize the element's `name` or `label` attributes.
+          * When using an accessibility identifier, prefix the selector with `~`.
+          * Use a precise XPath only if no stable accessibility identifier or resource-id is available.
         - "value": (String) The text to be entered into a field.
         - "original_step": (String) The original, unmodified natural language step.
 
@@ -73,9 +77,10 @@ async function getPageLoadIndicator(pageName, pageSource, aiService) {
         You are an expert Appium test automation engineer. The test is waiting for the "${pageName}" page to load.
         Analyze the provided XML page source and identify the single, most reliable selector for a stable element that is always present on the "${pageName}" page (e.g., a title, a navigation bar, or a main layout).
 
-        Prioritize selectors in this order:
-        1.  **resource-id**
-        2.  **content-desc**
+        Prefer stable accessibility identifiers when choosing a selector.
+        - On **Android**, look for `resource-id` first and then `content-desc`.
+        - On **iOS**, prefer the element's `name` or `label` attributes.
+        Prefix accessibility identifiers with `~`.
 
         **XML Page Source:**
         \`\`\`xml
@@ -174,9 +179,11 @@ async function findCorrectSelector(originalStep, pageSource, aiService) {
         You are an expert Appium test automation engineer. A test step has failed because the element could not be found. Your task is to analyze the provided XML page source and identify the single best selector for the element described in the original step.
 
         Prioritize selectors in this order:
-        1.  **resource-id** (if it is unique and descriptive)
-        2.  **content-desc** (accessibility ID)
-        3.  **A precise XPath**
+        1. **resource-id** (Android) or **name/label** (iOS) if unique and descriptive
+        2. **content-desc** (Android accessibility ID) or **name/label** (iOS)
+        3. **A precise XPath**
+
+        Prefix accessibility identifiers with `~` in the selector string.
 
         Here is the context:
 


### PR DESCRIPTION
## Summary
- retain iOS attributes when cleaning page source so AI can build selectors
- teach AI prompts to prefer iOS name/label accessibility IDs
- expand selector lookup to handle iOS name/label and search them in XPath
- added initial POM for iOS

------
https://chatgpt.com/codex/tasks/task_e_68b5485354cc832990fd330cdd4d0f48