### PR TITLE
Add BrowserStack pipeline and session artifact capture

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -1,0 +1,69 @@
+name: BrowserStack Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - platform: android
+            device: 'Samsung Galaxy S23'
+            os_version: '13.0'
+            app: ./path/to/android-app.apk
+          - platform: ios
+            device: 'iPhone 15'
+            os_version: '17'
+            app: ./path/to/ios-app.ipa
+    env:
+      BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+      BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+      TEST_PATH: tests/sample_login.json
+      AI_SERVICE: gemini
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+      - name: Install backend dependencies
+        working-directory: backend
+        run: npm ci
+      - name: Run BrowserStack tests
+        id: run-tests
+        working-directory: backend
+        env:
+          APP_PATH: ${{ matrix.app }}
+          PLATFORM: ${{ matrix.platform }}
+          DEVICE_NAME: ${{ matrix.device }}
+          OS_VERSION: ${{ matrix.os_version }}
+        run: npm run test:browserstack
+      - name: Collect BrowserStack artifacts
+        if: ${{ steps.run-tests.outputs.session_id }}
+        working-directory: backend
+        env:
+          SESSION_ID: ${{ steps.run-tests.outputs.session_id }}
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+        run: |
+          mkdir -p artifacts
+          curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" \
+            "https://api.browserstack.com/app-automate/sessions/$SESSION_ID.json" -o session.json
+          VIDEO_URL=$(jq -r '.automation_session.video_url' session.json)
+          LOG_URL=$(jq -r '.automation_session.appium_logs_url' session.json)
+          curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" "$VIDEO_URL" -o artifacts/${SESSION_ID}-video.mp4
+          curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" "$LOG_URL" -o artifacts/${SESSION_ID}-appium.log
+          echo "### BrowserStack Session $SESSION_ID" >> $GITHUB_STEP_SUMMARY
+          echo "- [Video]($VIDEO_URL)" >> $GITHUB_STEP_SUMMARY
+          echo "- [Appium Log]($LOG_URL)" >> $GITHUB_STEP_SUMMARY
+      - uses: actions/upload-artifact@v4
+        if: ${{ steps.run-tests.outputs.session_id }}
+        with:
+          name: browserstack-${{ matrix.platform }}-${{ matrix.os_version }}
+          path: backend/artifacts

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "main": "src/app.js",
   "scripts": {
     "start": "node src/app.js",
-    "dev": "nodemon src/app.js"
+    "dev": "nodemon src/app.js",
+    "test:browserstack": "node scripts/run-browserstack-tests.js"
   },
   "keywords": [
     "appium",

--- a/backend/scripts/run-browserstack-tests.js
+++ b/backend/scripts/run-browserstack-tests.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { executeTest } = require('../src/test-runner/test_executor');
+
+async function main() {
+  const appPath = process.env.APP_PATH;
+  const testsPath = process.env.TEST_PATH;
+  const platform = process.env.PLATFORM || 'android';
+  const deviceName = process.env.DEVICE_NAME || '';
+  const osVersion = process.env.OS_VERSION || '';
+  const aiService = process.env.AI_SERVICE || 'gemini';
+
+  if (!appPath || !testsPath) {
+    console.error('APP_PATH and TEST_PATH environment variables are required');
+    process.exit(1);
+  }
+
+  const rawStepsText = fs.readFileSync(path.resolve(testsPath), 'utf8');
+
+  const sessionId = await executeTest(
+    path.resolve(appPath),
+    rawStepsText,
+    { to: () => ({ emit: () => {} }) },
+    'cli',
+    aiService,
+    'browserstack',
+    platform,
+    deviceName,
+    osVersion,
+  );
+
+  console.log(`BrowserStack session ID: ${sessionId}`);
+
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `session_id=${sessionId}\n`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/backend/src/test-runner/test_executor.js
+++ b/backend/src/test-runner/test_executor.js
@@ -292,6 +292,7 @@ async function executeTest(
     platformVersion = '',
 ) {
     let browser;
+    let sessionId = null;
     // Normalise the platform once so that helper functions can use it.  This
     // variable persists through the lifetime of the test execution.
     const targetPlatform = (platform || 'android').toLowerCase();
@@ -377,7 +378,9 @@ async function executeTest(
 
         console.log('Attempting to start remote session...');
         browser = await remote({ ...appiumOptions, capabilities });
+        sessionId = browser.sessionId;
         console.log('Remote session started successfully.');
+        console.log(`BrowserStack session ID: ${sessionId}`);
 
         // --- NEW: Identify the app and prepare its specific cache ---
         // Use appPackage for Android or bundleId for iOS when caching selectors.
@@ -606,6 +609,7 @@ async function executeTest(
             console.error('Failed to delete uploaded app file:', fileCleanupError);
         }
      }
+    return sessionId;
 }
 
 /**


### PR DESCRIPTION
## Summary
- expose BrowserStack session IDs from test executor for downstream use
- provide CLI wrapper to run tests against BrowserStack
- introduce GitHub Actions workflow that runs tests on BrowserStack and uploads video/log artifacts

## Testing
- `node --check backend/scripts/run-browserstack-tests.js`
- `node --check backend/src/test-runner/test_executor.js`


------
https://chatgpt.com/codex/tasks/task_e_68b599c569d08329baf0f771fa51f1de