### PR TITLE
Support asterisk-wrapped element names in test executor

### DIFF
--- a/backend/src/test-runner/test_executor.js
+++ b/backend/src/test-runner/test_executor.js
@@ -615,11 +615,19 @@ async function executeTest(
  * @returns {string} The extracted element name or the original step.
  */
 function extractElementName(step) {
-    // This regex looks for text in single quotes, or the last word if no quotes are found.
+    // First, look for text wrapped in asterisks, e.g. *element*.
+    const asteriskMatch = step.match(/\*([^*]+)\*/);
+    if (asteriskMatch && asteriskMatch[1]) {
+        return `*${asteriskMatch[1]}*`;
+    }
+
+    // Fallback to text in single quotes, e.g. 'element'.
     const quoteMatch = step.match(/'([^']+)'/);
     if (quoteMatch && quoteMatch[1]) {
         return `'${quoteMatch[1]}'`;
     }
+
+    // Finally, return the last word if no special delimiters are found.
     const words = step.trim().split(' ');
     return words[words.length - 1];
 }
@@ -727,4 +735,4 @@ async function executeCommand(
     await browser.pause(1000);
 }
 
-module.exports = { executeTest };
+module.exports = { executeTest, extractElementName };

--- a/backend/src/test-runner/test_executor.js
+++ b/backend/src/test-runner/test_executor.js
@@ -618,7 +618,7 @@ function extractElementName(step) {
     // First, look for text wrapped in asterisks, e.g. *element*.
     const asteriskMatch = step.match(/\*([^*]+)\*/);
     if (asteriskMatch && asteriskMatch[1]) {
-        return `*${asteriskMatch[1]}*`;
+        return asteriskMatch[1].trim();
     }
 
     // Finally, return the last word if no special delimiters are found.

--- a/backend/src/test-runner/test_executor.js
+++ b/backend/src/test-runner/test_executor.js
@@ -621,12 +621,6 @@ function extractElementName(step) {
         return `*${asteriskMatch[1]}*`;
     }
 
-    // Fallback to text in single quotes, e.g. 'element'.
-    const quoteMatch = step.match(/'([^']+)'/);
-    if (quoteMatch && quoteMatch[1]) {
-        return `'${quoteMatch[1]}'`;
-    }
-
     // Finally, return the last word if no special delimiters are found.
     const words = step.trim().split(' ');
     return words[words.length - 1];

--- a/backend/src/test-runner/test_executor.test.js
+++ b/backend/src/test-runner/test_executor.test.js
@@ -1,0 +1,18 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+// Provide dummy AI service keys so requiring test_executor does not throw.
+process.env.GEMINI_API_KEY = 'dummy';
+process.env.DEEPSEEK_API_KEY = 'dummy';
+
+const { extractElementName } = require('./test_executor');
+
+test('extracts element name wrapped in asterisks', () => {
+    const step = "Tap the *Login* button";
+    assert.strictEqual(extractElementName(step), '*Login*');
+});
+
+test('extracts element name wrapped in single quotes', () => {
+    const step = "Tap the 'Login' button";
+    assert.strictEqual(extractElementName(step), "'Login'");
+});


### PR DESCRIPTION
## Summary
- Expand `extractElementName` to parse *element* markers before falling back to quotes or last word
- Export `extractElementName` and add unit tests for asterisk and quoted cases

## Testing
- `node --test backend/src/test-runner/test_executor.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b95136a74c8329be9b112c0e4d0f2d