### PR TITLE
feat: include locator strategy in selector cache

### DIFF
--- a/backend/pom_android.json
+++ b/backend/pom_android.json
@@ -1,11 +1,12 @@
 {
   "au.com.bws.debug": {
-    "login - ‘Email’": "au.com.bws.debug:id/emailEditText",
-    "login - ‘Password’": "au.com.bws.debug:id/passwordEditText",
-    "login - button": "au.com.bws.debug:id/loginBtn",
-    "home - 'search'": "au.com.bws.debug:id/search_button",
-    "initial - button": "au.com.bws.debug:id/loginBtn",
-    "home - page.": "au.com.bws.debug:id/delivery_option_container"
+    "login - ‘Email’ - resource-id": "au.com.bws.debug:id/emailEditText",
+    "login - ‘Password’ - resource-id": "au.com.bws.debug:id/passwordEditText",
+    "login - button - resource-id": "au.com.bws.debug:id/loginBtn",
+    "home - 'search' - resource-id": "au.com.bws.debug:id/search_button",
+    "initial - button - resource-id": "au.com.bws.debug:id/loginBtn",
+    "home - page. - resource-id": "au.com.bws.debug:id/delivery_option_container"
   },
   "au.com.bws.uat": {}
 }
+

--- a/backend/pom_ios.json
+++ b/backend/pom_ios.json
@@ -1,10 +1,11 @@
 {
   "au.com.bws.uat": {
-    "initial - button": "~LOG IN",
-    "login - ‘Email’": "~Email",
-    "login - ‘Password’": "~Password",
-    "login - button": "~Log in",
-    "home - page.": "~Delivery",
-    "home - 'search'": "~What can we get you?"
+    "initial - button - accessibility-id": "~LOG IN",
+    "login - ‘Email’ - accessibility-id": "~Email",
+    "login - ‘Password’ - accessibility-id": "~Password",
+    "login - button - accessibility-id": "~Log in",
+    "home - page. - accessibility-id": "~Delivery",
+    "home - 'search' - accessibility-id": "~What can we get you?"
   }
 }
+

--- a/backend/src/test-runner/test_executor.test.js
+++ b/backend/src/test-runner/test_executor.test.js
@@ -5,14 +5,26 @@ const assert = require('node:assert');
 process.env.GEMINI_API_KEY = 'dummy';
 process.env.DEEPSEEK_API_KEY = 'dummy';
 
-const { extractElementName } = require('./test_executor');
+const { extractElementName, determineLocatorStrategy } = require('./test_executor');
 
 test('extracts element name wrapped in asterisks', () => {
     const step = "Tap the *Login* button";
-    assert.strictEqual(extractElementName(step), '*Login*');
+    assert.strictEqual(extractElementName(step), 'Login');
 });
 
-test('extracts element name wrapped in single quotes', () => {
-    const step = "Tap the 'Login' button";
-    assert.strictEqual(extractElementName(step), "'Login'");
+test('returns last word when no delimiters are found', () => {
+    const step = "Tap the Login button";
+    assert.strictEqual(extractElementName(step), 'button');
+});
+
+test('detects accessibility-id strategy', () => {
+    assert.strictEqual(determineLocatorStrategy('~foo'), 'accessibility-id');
+});
+
+test('detects resource-id strategy', () => {
+    assert.strictEqual(determineLocatorStrategy('com.example:id/foo'), 'resource-id');
+});
+
+test('detects xpath strategy', () => {
+    assert.strictEqual(determineLocatorStrategy('//android.widget.TextView'), 'xpath');
 });


### PR DESCRIPTION
## Summary
- classify selectors with new `determineLocatorStrategy` helper
- include locator strategy in cache keys and migrate old POM entries
- update POM fixtures and tests for strategy-aware cache

## Testing
- `cd backend && node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b959e2c77883299b42e2cdc1a141bd