### PR TITLE
feat: derive cache strategy before lookup

### DIFF
--- a/backend/src/test-runner/test_executor.js
+++ b/backend/src/test-runner/test_executor.js
@@ -690,9 +690,12 @@ async function executeCommand(
     };
 
     // --- NEW, MORE ROBUST EXECUTION FLOW ---
+    // Derive the locator strategy from the AI-provided selector. If the
+    // AI omits a selector, fall back to "unknown" so the cache key is
+    // consistently formed.
+    const strategy = determineLocatorStrategy(safeCommand.selector || '');
     const elementName = extractElementName(safeCommand.original_step);
-    const initialStrategy = determineLocatorStrategy(safeCommand.selector);
-    const cacheKey = `${currentPageName} - ${elementName} - ${initialStrategy}`;
+    const cacheKey = `${currentPageName} - ${elementName} - ${strategy}`;
     let element;
     let finalSelector;
 

--- a/backend/src/test-runner/test_executor.test.js
+++ b/backend/src/test-runner/test_executor.test.js
@@ -28,3 +28,8 @@ test('detects resource-id strategy', () => {
 test('detects xpath strategy', () => {
     assert.strictEqual(determineLocatorStrategy('//android.widget.TextView'), 'xpath');
 });
+
+test('defaults to unknown strategy when selector is missing', () => {
+    assert.strictEqual(determineLocatorStrategy(), 'unknown');
+    assert.strictEqual(determineLocatorStrategy(''), 'unknown');
+});


### PR DESCRIPTION
## Summary
- derive locator strategy from AI selector (or fallback to `unknown`) before querying cache
- ensure cache keys always include page, element, and strategy
- test default `unknown` strategy

## Testing
- `node --test backend/src/test-runner/test_executor.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b998a81dfc8329ac4bf21f1be3d415