### PR TITLE
refactor: extract POM cache helpers

### DIFF
--- a/backend/src/test-runner/pom_cache.js
+++ b/backend/src/test-runner/pom_cache.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+const path = require('path');
+
+let POM_FILE_PATH = null;
+const pomCache = {};
+
+function determineLocatorStrategy(selector = '') {
+    if (!selector) return 'unknown';
+    if (selector.startsWith('~')) return 'accessibility-id';
+    if (selector.includes(':id/') || selector.includes('resource-id')) return 'resource-id';
+    if (selector.startsWith('//') || selector.startsWith('(')) return 'xpath';
+    return 'unknown';
+}
+
+function loadCache(platform = 'android') {
+    POM_FILE_PATH = path.join(
+        __dirname,
+        `../../pom_${platform}.json`,
+    );
+    try {
+        if (fs.existsSync(POM_FILE_PATH)) {
+            const data = fs.readFileSync(POM_FILE_PATH, 'utf8');
+            const parsed = JSON.parse(data);
+            const migratedCache = {};
+            let needsMigration = false;
+            for (const [key, selector] of Object.entries(parsed)) {
+                const parts = key.split(' - ');
+                if (parts.length === 2) {
+                    const [page, element] = parts;
+                    const strategy = determineLocatorStrategy(selector);
+                    migratedCache[`${page} - ${element} - ${strategy}`] = selector;
+                    needsMigration = true;
+                } else {
+                    migratedCache[key] = selector;
+                }
+            }
+            Object.keys(pomCache).forEach(key => delete pomCache[key]);
+            Object.assign(pomCache, migratedCache);
+            if (needsMigration) {
+                saveCache();
+            }
+            console.log(
+                `Successfully loaded ${platform} POM cache from ${path.basename(POM_FILE_PATH)}`,
+            );
+        } else {
+            Object.keys(pomCache).forEach(key => delete pomCache[key]);
+        }
+    } catch (error) {
+        console.error(
+            `Could not load POM cache from ${path.basename(POM_FILE_PATH)}:`,
+            error,
+        );
+        Object.keys(pomCache).forEach(key => delete pomCache[key]);
+    }
+}
+
+function saveCache() {
+    if (!POM_FILE_PATH) return;
+    try {
+        fs.writeFileSync(POM_FILE_PATH, JSON.stringify(pomCache, null, 2), 'utf8');
+        console.log(`POM cache saved to ${path.basename(POM_FILE_PATH)}`);
+    } catch (error) {
+        console.error(
+            `Could not save POM cache to ${path.basename(POM_FILE_PATH)}:`,
+            error,
+        );
+    }
+}
+
+module.exports = {
+    loadCache,
+    saveCache,
+    pomCache,
+};
+

--- a/backend/src/test-runner/test_executor.js
+++ b/backend/src/test-runner/test_executor.js
@@ -6,6 +6,7 @@ const fetch = (...args) => import('node-fetch').then(({ default: fetch }) => fet
 const FormData = require('form-data');
 // Import the updated NLP service functions
 const { translateStepsToCommands, findCorrectSelector } = require('../services/nlp_service');
+const { loadCache, saveCache, pomCache } = require('./pom_cache');
 
 // Import shared configuration.  This loads environment variables and
 // exposes BrowserStack credentials.  Avoid calling dotenv here to
@@ -17,75 +18,6 @@ const config = require('../config');
 // BrowserStack tests will throw an explicit error when attempted.
 const BROWSERSTACK_USERNAME = config.browserStackUsername;
 const BROWSERSTACK_ACCESS_KEY = config.browserStackAccessKey;
-
-// --- POM Caching Logic with Platform-Specific File Persistence ---
-let POM_FILE_PATH = null;
-let pomCache = {};
-
-/**
- * Loads the POM cache for the specified platform from disk.
- * Defaults to an empty cache if no file exists or loading fails.
- *
- * @param {string} platform - Either `android` or `ios`.
- */
-function loadCache(platform = 'android') {
-    POM_FILE_PATH = path.join(
-        __dirname,
-        `../../pom_${platform}.json`,
-    );
-    try {
-        if (fs.existsSync(POM_FILE_PATH)) {
-            const data = fs.readFileSync(POM_FILE_PATH, 'utf8');
-            pomCache = JSON.parse(data);
-            // Migrate old cache entries that lack a strategy suffix in the key
-            const migratedCache = {};
-            let needsMigration = false;
-            for (const [key, selector] of Object.entries(pomCache)) {
-                const parts = key.split(' - ');
-                if (parts.length === 2) {
-                    const [page, element] = parts;
-                    const strategy = determineLocatorStrategy(selector);
-                    migratedCache[`${page} - ${element} - ${strategy}`] = selector;
-                    needsMigration = true;
-                } else {
-                    migratedCache[key] = selector;
-                }
-            }
-            pomCache = migratedCache;
-            if (needsMigration) {
-                // Persist the migrated cache so future runs use the new format
-                saveCache();
-            }
-            console.log(
-                `Successfully loaded ${platform} POM cache from ${path.basename(POM_FILE_PATH)}`,
-            );
-        } else {
-            pomCache = {};
-        }
-    } catch (error) {
-        console.error(
-            `Could not load POM cache from ${path.basename(POM_FILE_PATH)}:`,
-            error,
-        );
-        pomCache = {}; // Start with an empty cache if loading fails
-    }
-}
-
-/**
- * Saves the current state of the POM cache to the platform-specific file.
- */
-function saveCache() {
-    if (!POM_FILE_PATH) return;
-    try {
-        fs.writeFileSync(POM_FILE_PATH, JSON.stringify(pomCache, null, 2), 'utf8');
-        console.log(`POM cache saved to ${path.basename(POM_FILE_PATH)}`);
-    } catch (error) {
-        console.error(
-            `Could not save POM cache to ${path.basename(POM_FILE_PATH)}:`,
-            error,
-        );
-    }
-}
 
 /**
  * Reduces the size of the XML to avoid API request limits.


### PR DESCRIPTION
## Summary
- move loadCache and saveCache into dedicated pom_cache module
- import new cache helpers in test_executor and remove inline definitions

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b9a5bf7e54832986d985033273265c