### PR TITLE
feat: add context switching utilities

### DIFF
--- a/backend/src/test-runner/context_utils.js
+++ b/backend/src/test-runner/context_utils.js
@@ -1,0 +1,51 @@
+const DEFAULT_TIMEOUT = 10000;
+
+/**
+ * Switch to the first available WebView context.
+ *
+ * @param {object} browser - WebdriverIO browser instance.
+ * @param {number} [timeout=DEFAULT_TIMEOUT] - How long to wait for a WebView.
+ */
+async function switchToWebview(browser, timeout = DEFAULT_TIMEOUT) {
+    const start = Date.now();
+    while (Date.now() - start < timeout) {
+        try {
+            const contexts = await browser.getContexts();
+            const webviewContext = contexts.find((ctx) => ctx && ctx.startsWith('WEBVIEW'));
+            if (webviewContext) {
+                const currentContext = await browser.getContext();
+                if (currentContext !== webviewContext) {
+                    console.log(`Switching to WebView context: ${webviewContext}`);
+                    await browser.switchContext(webviewContext);
+                } else {
+                    console.log(`Already in WebView context: ${webviewContext}`);
+                }
+                return;
+            }
+        } catch (err) {
+            console.log(`Error getting contexts: ${err.message}`);
+        }
+        await browser.pause(500);
+    }
+    throw new Error('WEBVIEW context not found within timeout');
+}
+
+/**
+ * Switch back to the native app context.
+ *
+ * @param {object} browser - WebdriverIO browser instance.
+ */
+async function switchToNative(browser) {
+    const currentContext = await browser.getContext();
+    if (currentContext !== 'NATIVE_APP') {
+        console.log('Switching to native context: NATIVE_APP');
+        await browser.switchContext('NATIVE_APP');
+    } else {
+        console.log('Already in native context: NATIVE_APP');
+    }
+}
+
+module.exports = {
+    switchToWebview,
+    switchToNative,
+};


### PR DESCRIPTION
## Summary
- add utilities to switch between WebView and native contexts with logging
- ensure test executor switches contexts appropriately before and after web interactions
- support explicit "wait for app to load webview/native view" steps for targeted context waits

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68bd5321e9108329bed658ba4630bb20